### PR TITLE
status-history-modal comment tooptip overlay

### DIFF
--- a/src/modules/AnalysisExecution/components/ViewEditAnalysis/ModalStatusHistory/presenter.jsx
+++ b/src/modules/AnalysisExecution/components/ViewEditAnalysis/ModalStatusHistory/presenter.jsx
@@ -45,14 +45,18 @@ function StatusListItem({ status }) {
             {...classes({ element: 'status', modifiers })}
           >
               {status.title}
-              <div
-                {...classes({ element: 'comment', extra: 'ac-tooltip' })}
-                aria-label={`Comment: ${status.comment}`}
-                data-tootik-conf='bottom multiline'
-              >
+              <div {...classes('tooltip-container')}>
+                  <div {...classes('tooltip-wrapper')}>
+                      <div
+                          {...classes({element: 'comment', extra: 'ac-tooltip'})}
+                          aria-label={`Comment: ${status.comment}`}
+                          data-tootik-conf='bottom multiline'
+                      >
                 <span
-                  {...classes('comment-ico')}
+                    {...classes('comment-ico')}
                 >comment</span>
+                      </div>
+                  </div>
               </div>
           </td>
       }

--- a/src/modules/AnalysisExecution/components/ViewEditAnalysis/ModalStatusHistory/style.scss
+++ b/src/modules/AnalysisExecution/components/ViewEditAnalysis/ModalStatusHistory/style.scss
@@ -53,6 +53,17 @@
 	    text-transform: initial;
 		}
 
+		&__tooltip-container {
+			position: absolute;
+			display: inline;
+		}
+
+		&__tooltip-wrapper {
+			position: relative;
+			display: inline;
+			bottom: 1rem;
+		}
+
 		&__comment-ico {
 			@include material-icon();
 			color: $black;


### PR DESCRIPTION
change overflow mode on the status-history-modal to avoid comment tooltip cutoff