### PR TITLE
upgrade node-sass library dute to the error:

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "imports-loader": "^0.6.5",
     "jsdom": "^9.8.0",
     "mocha": "^3.1.2",
-    "node-sass": "4.9.0",
+    "node-sass": "4.12.0",
     "null-loader": "^0.1.1",
     "path": "^0.12.7",
     "piping": "^0.3.0",


### PR DESCRIPTION
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-sass@4.9.0 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-sass@4.9.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.